### PR TITLE
Update SignInViewController.swift

### DIFF
--- a/unnamed dashboard app/ViewControllers/SignInViewController.swift
+++ b/unnamed dashboard app/ViewControllers/SignInViewController.swift
@@ -54,17 +54,21 @@ class SignInViewController: UIViewController {
         //        topLogo.alpha = 0.0
         //        UIView.animateWithDuration(3.0) {
         //          self.topLogo.alpha = 1.0
-    }
-    // get a reference to our CopperKit application instance
-    // get a reference to our CopperKit application instance
-    @IBAction func signinButtonPressed(sender: AnyObject){
-        copper = C29Application.sharedInstance
+        
+                copper = C29Application.sharedInstance
         // Required: configure it with our app's token
         copper!.configureForApplication("579A489835846340FC4C4B41A8FD48B5893B470C")
         // Optionally, decide what information we want from the user, defaults to C29Scope.DefaultScopes = [C29Scope.Name, C29Scope.Picture, C29Scope.Phone]
         copper!.scopes = desiredScopes
+    }
+    // get a reference to our CopperKit application instance
+    // get a reference to our CopperKit application instance
+    @IBAction func signinButtonPressed(sender: AnyObject){
+        guard let copper = copper where !copper.authenticated else {
+            self.performSegueWithIdentifier("hello", sender: self)
+        }
         // OK, let's make our call
-        copper!.login(withViewController: self, completion: { (result: C29UserInfoResult) in
+        copper.login(withViewController: self, completion: { (result: C29UserInfoResult) in
             switch result {
             case let .Success(userInfo):
 //                let user = User()


### PR DESCRIPTION
Here are some changes ... untested and I wrote these in github, so I didn't have an editor checking my work, which explains if you see syntax errors.

Here's what I did:

Moved the instantiation and setup of the copper object to viewDidLoad(). It's a better place for them. Plus it gives us options, and I'm not sure what user experience you prefer:

Option 1: As the code is written, we will check for copper.authenticated, and if it exists, we segue right away.
>>>> NOTE!!!!!: I'm realizing we need a 'return' beneath self.performSegue... on line 69. Please add that.

Option 2: You can cut+paste the entire guard { } statement from signInButtonPressed() into viewDidAppear() (you would need to create this). This would run the check on load of the view controller, removing the need for the user to tap a button. 
>>>> NOTE!!!!!: fix the error in the NOTE in Option 1 before Option 2 ;)
>>>> NOTE2!!!!!: you will need to update line 71 to copper!.login(... (notice the !) if you move the guard { } statement from this method.

